### PR TITLE
STS assume role with web id validation and error responses - EUCA-12566

### DIFF
--- a/clc/modules/tokens/src/main/java/com/eucalyptus/tokens/TokensException.java
+++ b/clc/modules/tokens/src/main/java/com/eucalyptus/tokens/TokensException.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2014 Eucalyptus Systems, Inc.
+ * Copyright 2009-2016 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +32,10 @@ public class TokensException extends EucalyptusCloudException {
 
   enum Code {
     AccessDenied( HttpResponseStatus.FORBIDDEN, "Sender" ),
+    ExpiredTokenException,
+    IDPCommunicationError,
     InvalidAction,
+    InvalidIdentityToken,
     InvalidParameterValue,
     MissingAuthenticationToken( HttpResponseStatus.FORBIDDEN, "Sender" ),
     ServiceUnavailable( HttpResponseStatus.SERVICE_UNAVAILABLE, "Receiver" ),


### PR DESCRIPTION
Updates to parameter validation and error responses to match aws/sts. With these changes the following test passes:

  https://github.com/sjones4/n4j/commits/sts-assume-role-with-web-identity

There was some info missing from the success response which is now added. Fetching data for oidc discovery is also modified to allow size checks and remove use of the Scanner.
